### PR TITLE
Re-implement python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This work clones the main Triton repository, but intends to minimize
 divergences in the core. Most of the autodiff work is in [third_party/autodiff](third_party/autodiff)
 subdirectory.
 
-**NOTE: This project is in its early stages and under heavy development -- it is not stable, not feature complete, and APIs will change.**
+**NOTE: This project is in its early stages and under heavy development -- it is not yet stable, not yet feature complete, and APIs will change.**
 
 
 # Motivation
@@ -370,19 +370,11 @@ q.requires_grad = True
 k.requires_grad = True
 v.requires_grad = True
 
-+ from triton.backends.autodiff import autodiff, right_partial
++ from triton.backends.autodiff import autodiff
 
-+ # temporary limitation:
-+ #   here need right_partial because binding trailing arguments (not arguments at the beginning), because kernel signature
-+ #   happen to have these at the end. Now this uses the stub which only needs grad args (non grad args have been bound)
-+ stub = right_partial(stub, causal, sm_scale)
++ my_op = autodiff(kernel, stub, idx_upstream=5, idxs_buffers=[3])
 
-+ my_op, bwd_kernel = autodiff(kernel, stub, grid, idx_upstream=5, non_stub_args_idxs=[3])
-
-+ # temporary limitation: run stub once before calling my_op
-+ stub(bwd_kernel, q, k, v)
-
-+ my_out = my_op(q, k, v)
++ my_out = stub(my_op, q, k, v)
 + my_out.backward(upstream)
 
 + # now grads have been populated for: q.grad, k.grad, v.grad
@@ -579,12 +571,9 @@ bias.requires_grad = True
 
 + from triton.backends.autodiff import autodiff
 
-+ my_op, bwd_kernel = autodiff(kernel, stub, grid=(M,), non_stub_args_idxs=[4,5], idx_upstream=1)
++ my_op = autodiff(kernel, stub, idx_upstream=1, idxs_buffers=[4, 5])
 
-+ # temporary limitation: run stub once before calling my_op
-+ stub(bwd_kernel, x, weight, bias)
-
-+ my_out = my_op(x, weight, bias)
++ my_out = stub(my_op, x, weight, bias)
 + my_out.backward(upstream)
 
 + # now grads have been populated for: x.grad, weight.grad, bias.grad

--- a/third_party/autodiff/python/api.py
+++ b/third_party/autodiff/python/api.py
@@ -112,7 +112,7 @@ def clone_jit_function(jit_func):
     return cloned
 
 # it's not as much as a stub, but more like helper to wrap_bwd_kernel from kernel_inputs -- the true stub is the user thing, this thing just piggy backs on the true stub
-def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, kernel_inputs, upstream):
+def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, grid, kernel_inputs, upstream):
 
 
     # # todo: understand more
@@ -179,7 +179,7 @@ def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, kernel_i
     if VERBOSE: print("[wrap_bwd_kernel] fwd_args:", kernel_inputs)
     if VERBOSE: print("[wrap_bwd_kernel] bwd_args:", bwd_args)
 
-    bwd_kernel[(1,)](*kernel_inputs, *bwd_args)
+    bwd_kernel[grid](*kernel_inputs, *bwd_args)
     # bwd_kernel.run(grid=grid, warmup=False, *kernel_inputs, *bwd_args)
 
     print("[wrap_bwd_kernel] bwd_args (after calling bwd_kernel): ", bwd_args)
@@ -202,7 +202,7 @@ def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, kernel_i
     # #       but kernel actually sees (q, k, v, M, OUT, [other non-tensor arguments]) -- and your wrap_bwd_kernel create grad tensors for all tensor arguments (to feed to bwd_kernel) and then returns all added grad_tensor arguments
     # #       (which would also contain grad_M, grad_OUT) but because these M or OUT weren't passed to the autograd.Function.forwad, in autograd.Function.backward, it's incorrect to return grads wrt these values
     # #       so need a way to only return grad wrt fwd stub args (and NOT wrt all bwd_kernel tensor args)
-    
+
     # # use reverse to avoid shifting issues
     # # for i in reversed(non_stub_args_idxs):
     # #     # for the stub args which are **after** the popped upstream_idx,
@@ -483,10 +483,8 @@ triton.runtime.jit.JITFunction.compiled_hook = my_post_hook
 class DifferentiatedCompiledKernel(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, kernels, idxs, *fwd_kernel_inputs): # , grid
+    def forward(ctx, kernels, idxs, grid, *fwd_kernel_inputs): # , grid
         if VERBOSE: print("\n"*3, "Op.forward")
-
-        grid = (1, )
 
         fwd_kernel, wrapped_bwd_kernel = kernels
         idx_upstream, idxs_buffers = idxs
@@ -571,13 +569,13 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
 
         # wrapped_bwd_kernel does return grad_inputs that it initialized, after running the
         # generated_bwd_kernel these are populated -- and contain grads wrt original tensor inputs
-        grads = ctx.wrapped_bwd_kernel(ctx.idxs_buffers, fwd_kernel_inputs, upstream) # ctx.grid, 
+        grads = ctx.wrapped_bwd_kernel(ctx.idxs_buffers, ctx.grid, fwd_kernel_inputs, upstream) # ctx.grid, 
         if VERBOSE: print("[Op.backward] grads", grads)
 
         # at this point your "grads" value has grads wrt args of fwd kernel (including grad wrt kernel out itself
         # -- not popping it in wrap_bwd_kernel because here I'm required to return grads wrt ALL inputs which passed to AG.fwd)
         # todo-now: need to return grad for non tensor inputs
-        return (None, None, *grads, None)
+        return (None, None, None, *grads, None)
 
 
 
@@ -585,47 +583,41 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
 
 def autodiff(fwd_kernel, stub, idx_upstream, idxs_buffers=None):
 
-    def kwargify(AutogradFunc, spec=None):
+    def helper(AutogradFunc, spec, kernels, idxs):
         # returns a subclass of `AutogradFunc` whose .apply accepts keywords
         # AutogradFunc.forward stays (ctx, *args, **kwargs) -- fine as long as it can consume the ordered list I pass in
 
         target_sig = inspect.signature(spec)
-        print("[kwargify] target_sig", target_sig)
+        if VERBOSE: print("[helper] target_sig", target_sig)
         params = target_sig.parameters.values()
-        print("[kwargify] params", params)
+        if VERBOSE: print("[helper] params", params)
 
-        class _Kwargify(AutogradFunc):
+        class _Helper(AutogradFunc):
             # __signature__ = target_sig          # IDE/help friendly
             __doc__       = AutogradFunc.__doc__
             __name__      = AutogradFunc.__name__
             __qualname__  = AutogradFunc.__qualname__
 
-            # todo-now: add args to sig for: kernels, idxs, grid
             @classmethod
-            def apply(cls, kernels, idxs, *args, **kwargs): # grid, 
-                print("[_Kwargify.apply] args", args)
-                print("[_Kwargify.apply] kwargs", kwargs)
-                # print("[_Kwargify.apply] grid", grid)
+            def apply(cls, *args, **kwargs):
+                if VERBOSE: print("[_Helper.apply] args", args)
+                if VERBOSE: print("[_Helper.apply] kwargs", kwargs)
+                # if VERBOSE: print("[_Helper.apply] grid", cls.grid)
                 bound = target_sig.bind_partial(*args, **kwargs)
                 bound.apply_defaults()
                 # fixed positional order for c++ apply
                 ordered = [bound.arguments[p.name] for p in params]
-                return super().apply(kernels, idxs, *ordered) # grid,
+                return super().apply(kernels, idxs, cls.grid, *ordered)
 
-        return _Kwargify
+            # operates on the class level -- not on the instances of the class,
+            # because in pytorch instances of torch.autograd.Function never created
+            @classmethod
+            def __class_getitem__(cls, grid):
+                # mutate the existing class
+                cls.grid = grid
+                return cls.apply
 
-    def make_indexable(fn):
-        class Indexable:
-            def __getitem__(self, grid):
-                # return lambda *args, **kwargs: fn(grid, [*args, kwargs])
-                # below is needed for debugging:
-                def wrapper(*args, **kwargs):
-                    out = fn(grid, *args, **kwargs)
-                    for o in out:
-                        print("[Indexable] o.grad_fn", o) # o.grad_fn)
-                    # note returns nothing -- as regular triton kernels do
-                return wrapper
-        return Indexable()
+        return _Helper
 
 
     # make my assumption explicit (same as api-v2)
@@ -658,12 +650,12 @@ def autodiff(fwd_kernel, stub, idx_upstream, idxs_buffers=None):
 
     wrapped_bwd_kernel = partial(wrap_bwd_kernel, fwd_kernel, bwd_kernel, idx_upstream)
 
-    # takes the signature form fwd_kernel's python fn
-    kwargified_op = kwargify(DifferentiatedCompiledKernel, fwd_kernel.fn)
 
     kernels = (fwd_kernel, wrapped_bwd_kernel)
     idxs = (idx_upstream, idxs_buffers)
-    op = partial(kwargified_op.apply, kernels, idxs)
+
+    # takes the signature form fwd_kernel's python fn
+    op = helper(DifferentiatedCompiledKernel, fwd_kernel.fn, kernels, idxs)
 
     # avoid user needing to pass grid parameter explicitly
     # because wrapped_bwd_kernel will called from inside the user stub inplace of the original

--- a/third_party/autodiff/python/api.py
+++ b/third_party/autodiff/python/api.py
@@ -20,6 +20,10 @@ VERBOSE = int(os.environ.get('VERBOSE', 0))
 assert VERBOSE in [0, 1, 2]
 
 dir = os.getenv("TRITON_AUTODIFF_DIR")
+if dir is None:
+    raise ValueError("Please specify TRITON_AUTODIFF_DIR, see README.")
+
+# todo: don't hardcode
 tool = f"{dir}/python/build/cmake.linux-x86_64-cpython-3.12/bin/triton-opt"
 
 
@@ -85,43 +89,6 @@ def run_mlir_pass(path):
 
 
 
-bwd_kernel = None
-
-class StashArgsCtx:
-    _active_instance = None
-
-    def __enter__(self):
-        type(self)._active_instance = self
-        self.args = None
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        type(self)._active_instance = None
-
-
-# hook is called on the Python side with the same *args, **kwargs you pass when you launch the kernel
-# to keep track of the shapes of the tensors (seems by default this info is not accessible form the bwd hook alone)
-def shape_track_hook(*args, **kwargs):
-
-    # fwd_shapes.clear()
-
-    ctx = StashArgsCtx._active_instance
-    if ctx is not None:
-        _kwargs = kwargs.copy()
-        # these kwargs are injected automatically
-        # launch‑options, not ordinary kernel parameters
-        _kwargs.pop("debug", None)
-        # todo-high: understand more
-        _kwargs.pop("num_warps", None)
-        _kwargs.pop("num_ctas", None)
-        # enable_fp_fusion
-        # launch_cooperative_grid
-
-        ctx.args = [*args, *_kwargs] # [weakref.ref(arg) for arg in args]
-        # if VERBOSE: print("[shape_track_hook] kwargs", _kwargs)
-
-
-
 def clone_jit_function(jit_func):
     assert isinstance(jit_func, JITFunction)
 
@@ -144,17 +111,44 @@ def clone_jit_function(jit_func):
 
     return cloned
 
+# it's not as much as a stub, but more like helper to wrap_bwd_kernel from kernel_inputs -- the true stub is the user thing, this thing just piggy backs on the true stub
+def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, grid, kernel_inputs, upstream):
 
-# it's not as much as a stub, but more like helper to create_bwd_kernel_inputs from kernel_inputs -- the true stub is the user thing, this thing just piggy backs on the true stub
-def create_bwd_kernel_inputs(bwd_kernel, idx_upstream, grid, non_stub_args_idxs, kernel_inputs, upstream):
 
-    # todo: add input checks
+    # # todo: understand more
+    # # these kwargs are injected automatically
+    # # launch‑options, not ordinary kernel parameters
+    # _kwargs = kwargs.copy()
+    # _kwargs.pop("debug", None)
+    # _kwargs.pop("num_warps", None)
+    # _kwargs.pop("num_ctas", None)
+    # # enable_fp_fusion
+    # # launch_cooperative_grid
+
+    # todo-low: add input checks
     # assert a.device == DEVICE and b.device == DEVICE and upstream.device == DEVICE
 
+
+    # todo-high: [support re-tracing]
+    # for now still relying on bwd_kernel._autodiff_info, but for re-tracing seems need a more general
+    # appraoch (supports interleaving calls to different CompiledKernels in the cache), but the bwd_kernel._autodiff_info is
+    # more limited as it only keeps info about the last CompiledKernel -- last compiled != last called
+    #   Thus passing fwd_kernel here
+    #     to extract it's cache directly;
+    #     then find what CompiledKernel in the fwd pass corresponds to the current args (kernel_inputs);
+    #     and then extract what idx were specialized in fwd CompiledKernel directly from that CompiledKernel
+    #  passing fwd_kernel to support re-tracing: to be able to dynamically figure which FWD
+    #   compileKernel does the kernel_inputs (passed to the current fn) correspond to, to extract what inputs were
+    #   specized in the fwd -- so that you don't need to pass that specialized idx (for a particular fwd CompiledKernel)
+    #   through some global dict
+
+    if VERBOSE:  print("[wrap_bwd_kernel] kernel_inputs", kernel_inputs)
+
     # fwd specializes away some arguments (so that they aren't arguments in the fwd TTIR,
-    # and thus not arguments in bwd TTIR as well) -- so don't pass them bwd TTIR
+    # and thus not arguments in bwd TTIR as well) -- so don't pass them to bwd TTIR
+    if VERBOSE: print("[wrap_bwd_kernel] bwd_kernel._autodiff_info: ", bwd_kernel._autodiff_info)
     idx_folded = bwd_kernel._autodiff_info[-1]
-    if VERBOSE: print("[create_bwd_kernel_inputs] idx_folded: ", idx_folded)
+    if VERBOSE: print("[wrap_bwd_kernel] idx_folded: ", idx_folded)
     # user provided idx of output (idx_upstream) in terms of all args to fwd python kernel
     # (JITFunction), when it compiled, some of the args potentially got specialized away.
     # Thus here need to shift that user specified index to account for these args (that got
@@ -166,7 +160,7 @@ def create_bwd_kernel_inputs(bwd_kernel, idx_upstream, grid, non_stub_args_idxs,
         if i < idx_upstream:
             num_folded_before_upstream += 1
 
-    # if VERBOSE: print("[create_bwd_kernel_inputs] idx_folded", idx_folded)
+    # if VERBOSE: print("[wrap_bwd_kernel] idx_folded", idx_folded)
     # if VERBOSE: print("num_folded_before_upstream:", num_folded_before_upstream)
 
     bwd_args = []
@@ -177,40 +171,50 @@ def create_bwd_kernel_inputs(bwd_kernel, idx_upstream, grid, non_stub_args_idxs,
         if isinstance(arg, torch.Tensor):
             bwd_args.append(torch.zeros_like(arg))
 
-    # if VERBOSE: print("[create_bwd_kernel_inputs] fwd_args:", kernel_inputs)
-    # if VERBOSE: print("[create_bwd_kernel_inputs] bwd_args:", bwd_args)
+    # todo:
+    #   some err handling for weird cases where fwd JITFcuntio has't ran
+    #   with that signature yet -- so my wrapping didnt' take place -- so
+    #   calling the bellow will fail
+
+    if VERBOSE: print("[wrap_bwd_kernel] fwd_args:", kernel_inputs)
+    if VERBOSE: print("[wrap_bwd_kernel] bwd_args:", bwd_args)
+
     bwd_kernel[grid](*kernel_inputs, *bwd_args)
-    # if VERBOSE: print("[create_bwd_kernel_inputs] grads", bwd_args)
+    # bwd_kernel.run(grid=grid, warmup=False, *kernel_inputs, *bwd_args)
 
-    # remove upstream grad
-    # Use num_folded_before_upstream, otherwise assumes all args are tensors (IOW: grad inputs are 1:1 with
-    # inputs) -- but it's not always the case, so this causes idx (in terms of fwd args) not match idx (in terms of
-    # grad args)
-    bwd_args.pop(idx_upstream - num_folded_before_upstream)
+    print("[wrap_bwd_kernel] bwd_args (after calling bwd_kernel): ", bwd_args)
 
-
-    # todo-now: an automatic way of solving this seems would require a new implementation of python API (V3)
-    #   create_bwd_kernel_inputs really computes grad wrt inputs to fwd_KERNEL not the inputs to the fwd_stub -- how should you wire this into the autograd system?
-    #       seems like you need do step of: given grads wrt fwd_kernel inputs; select only the ones that are grads wrt stub_fwd inputs
+    # don't need to pop grad wrt upstream anymore bc now (when my AG.Function works on lvl of kernels, but not stubs)
+    # I actually do need to return grads wrt each of the inputs of the kernel inputs (including the out buffers):
     #
-    #   capture stub and create_bwd_kernel_inputs by closure -- instead of passing them as inputs to forward() -- otherwise autograd requires to return same number of grads
-    #   cannot just pass "def forward(ctx, stub, create_bwd_kernel_inputs, *stub_inputs)" and later bind stub and create_bwd_kernel_inputs -- bc even if bind and thus won't need to feed them them at runtime, autograd still sees 4 args and therefore will err when by bwd retunrs only 2 grads (wrt to the 2 args) -- it would expect I should return 4 args (as the number of args to autograd.Function.forward)
-    #   E.g. for flash aten kernel user fwd stub creates some additional tensor args and passes them to the kernel (e.g. M, OUT) and feeds them to the kernel but the user calls stub with "my_op(q, k, v)" -- so the autograd.Function.forward also only expects "q, k, v"
-    #       but kernel actually sees (q, k, v, M, OUT, [other non-tensor arguments]) -- and your create_bwd_kernel_inputs creates grad tensors for all tensor arguments (to feed to bwd_kernel) and then returns all added grad_tensor arguments
-    #       (which would also contain grad_M, grad_OUT) but because these M or OUT weren't passed to the autograd.Function.forwad, in autograd.Function.backward, it's incorrect to return grads wrt these values
-    #       so need a way to only return grad wrt fwd stub args (and NOT wrt all bwd_kernel tensor args)
+    # # remove upstream grad
+    # # Use num_folded_before_upstream, otherwise assumes all args are tensors (IOW: grad inputs are 1:1 with
+    # # inputs) -- but it's not always the case, so this causes idx (in terms of fwd args) not match idx (in terms of
+    # # grad args)
+    # bwd_args.pop(idx_upstream - num_folded_before_upstream)
 
-    # use reverse to avoid shifting issues
-    for i in reversed(non_stub_args_idxs):
-        # for the stub args which are **after** the popped upstream_idx,
-        # shift them by 1 to account for the grad_out that I popped just above
-        bwd_args.pop(i) if i < idx_upstream else bwd_args.pop(i - 1)
+    # print("[wrap_bwd_kernel] bwd_args (after popping grad wrt out): ", bwd_args)
 
-    # unpack list
+
+    # #   capture stub and wrap_bwd_kernel args by closure -- instead of passing them as inputs to forward() -- otherwise autograd requires to return same number of grads
+    # #   cannot just pass "def forward(ctx, stub, wrap_bwd_kernel, *stub_inputs)" and later bind stub and wrap_bwd_kernel -- bc even if bind and thus won't need to feed them them at runtime, autograd expect I should return 4 args (as the number of args to autograd.Function.forward)
+    # #   E.g. for flash aten kernel user fwd stub creates some additional tensor args and passes them to the kernel (e.g. M, OUT) and feeds them to the kernel but the user calls stub with "my_op(q, k, v)" -- so the autograd.Function.forward also only expects "q, k, v"
+    # #       but kernel actually sees (q, k, v, M, OUT, [other non-tensor arguments]) -- and your wrap_bwd_kernel create grad tensors for all tensor arguments (to feed to bwd_kernel) and then returns all added grad_tensor arguments
+    # #       (which would also contain grad_M, grad_OUT) but because these M or OUT weren't passed to the autograd.Function.forwad, in autograd.Function.backward, it's incorrect to return grads wrt these values
+    # #       so need a way to only return grad wrt fwd stub args (and NOT wrt all bwd_kernel tensor args)
+    
+    # # use reverse to avoid shifting issues
+    # # for i in reversed(non_stub_args_idxs):
+    # #     # for the stub args which are **after** the popped upstream_idx,
+    # #     # shift them by 1 to account for the grad_out that I popped just above
+    # #     bwd_args.pop(i) if i < idx_upstream else bwd_args.pop(i - 1)
+
+    print("[wrap_bwd_kernel] returning", bwd_args)
+
+    # unpack
     return (*bwd_args,)
 
 
-# def my_post_hook(stub):
 def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
 
     def key_add_args(key):
@@ -246,7 +250,7 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
         # new_key:  [('*fp32', 'D'), ('*fp32', 'D'), ('*fp32', 'D'), ('*f32', 'D'), ('*f32', 'D'), ('*f32', 'D')]{'debug': False}
         return new_key
 
-    def rebuild_binder(fn, delta, backend):
+    def rebuild_binder(jit_fn, delta, backend):
         """
         1 – update signatures	create_function_from_signature looks at fn.jit_function.signature and fn.jit_function.metadata.arg_types. If you forget to patch either, the binder will still have the old arity and you will hit TypeError: dynamic_func() takes N positional arguments… at launch 
         2 – new binder	The helper builds the little Python function (dynamic_func) that maps user launch args → positional tuple for the GPU call
@@ -263,38 +267,37 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
         if VERBOSE: print(f"adding {delta} args")
 
         # 1. extend the Python signature *before* we rebuild the binder
-        sig_params = list(fn.jit_function.signature.parameters.values())
+        sig_params = list(jit_fn.signature.parameters.values())
         for i in range(delta):
             p = inspect.Parameter(
                 f"grad_{i}",
                 inspect.Parameter.POSITIONAL_OR_KEYWORD,
                 annotation="tl.float16*" # "tl.pointer"
             )
-            fn.jit_function.params.append(KernelParam(len(fn.jit_function.params), p, False, False)) # dns= dns_oa= , annotation="tl.float16*"
+            jit_fn.params.append(KernelParam(len(jit_fn.params), p, False, False)) # dns= dns_oa= , annotation="tl.float16*"
             sig_params.append(p)
-        if VERBOSE: print("fn.jit_function.signature: ", fn.jit_function.signature)
-        if VERBOSE: print("fn.jit_function self.params:", fn.jit_function.params)
-        fn.jit_function.signature = fn.jit_function.signature.replace(parameters=sig_params)
+        if VERBOSE: print("jit_fn.signature: ", jit_fn.signature)
+        if VERBOSE: print("jit_fn self.params:", jit_fn.params)
+        jit_fn.signature = jit_fn.signature.replace(parameters=sig_params)
 
         # 2. build a fresh binder
         new_binder = create_function_from_signature(
-                        fn.jit_function.signature,
-                        fn.jit_function.params,
+                        jit_fn.signature,
+                        jit_fn.params,
                         backend)
 
         return new_binder
 
 
-    if not already_compiled:
+    jit_fn = fn.jit_function  # JITFunction
 
-        # todo-now: find a cleaner way -- compile hook registers on all instances of JITFunction, but i want this hook to trigger only on bwd JITFuncton
-        if fn.jit_function is not bwd_kernel:
-            if VERBOSE: print("fn.jit_function is not bwd_kernel", id(fn.jit_function), id(bwd_kernel))
-            return
-        else:
-            if VERBOSE: print("post hook triggered on the bwd!")
+    # compile hook registers on all instances of JITFunction, but i want this hook to trigger only on fwd JITFunctons
+    if not already_compiled and hasattr(jit_fn, '_is_fwd_kernel'):
+
+        if VERBOSE: print("[my hook] compile hook triggered on the fwd JITFunction!")
 
         compile_dict = compile
+        bwd_jit_fn = jit_fn._bwd_kernel
 
         if VERBOSE: print(f"Kernel {fn.name} just finished executing!")
         if VERBOSE: print(f"Representation: {repr}")
@@ -304,13 +307,16 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
         # The same key that's passed to the hook is the one used to store the kernel in the cache.
 
         # 1) extract fwd_compiled_kernel
-        # Get the device
-        device = driver.active.get_current_device()
-        # Access the kernel from the cache
-        jit_fn = fn.jit_function  # This is the JITFunction instance
-        kernel_cache, target, backend, _binder = jit_fn.device_caches[device]  # First element is the kernel cache dict
-        fwd_compiled_kernel = kernel_cache[key]  # Get the kernel using the same key
 
+        # Access the kernel from the cache
+        device = driver.active.get_current_device()
+        fwd_kernel_cache, target, backend, _binder = jit_fn.device_caches[device]
+        bwd_kernel_cache, target, backend, _binder = bwd_jit_fn.device_caches[device]
+
+        # Get the kernel using the same key
+        fwd_compiled_kernel = fwd_kernel_cache[key]
+
+        # 2) write fwd IR
 
         # todo: cleanup
         # the "key" arg is just a python string with input signatures of the kernel
@@ -319,7 +325,6 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
         dir_name = hash_object.hexdigest()[:10]
         if VERBOSE: print("dir_name: ", dir_name)
 
-        # 2) write fwd IR
         os.makedirs(f"generated/{dir_name}", exist_ok=True)
         with open(f"generated/{dir_name}/inp.ttir", "w") as f:
           f.write(fwd_compiled_kernel.asm['ttir'])
@@ -327,7 +332,7 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
         # 3) autodiff
         run_mlir_pass(f"generated/{dir_name}")
 
-        # 4) create executable python fn for bwd
+        # 4) create callable python fn for bwd
         from triton.compiler import compile
         from triton.backends.compiler import GPUTarget
 
@@ -345,28 +350,25 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
         # if VERBOSE: print(bwd_compiled_kernel.asm['ttgir'])
 
 
-        # 5) replace original fwd CompiledKernel with autograd.Function (replaces cache entry in the cache of JITFunction)
-
-        #   bwd_kernel is a CompiledKernel and I can directly swap original compiled kernel with this CompiledKernel
-        #   And because this never calls a stub (no possibility for recursion).
+        # 5) keep original fwd CompiledKernel with autograd.Function and add corresponding cache entry (with differentiated CompiledKernel) to cache of bwd JITFunction
 
         # if VERBOSE: print(dir(jit_fn.device_caches[device][0][key]))
         # '_init_handles', 'asm', 'function', 'hash', 'kernel', 'launch_enter_hook', 'launch_exit_hook', 'launch_metadata', 'metadata', 'module', 'name', 'packed_metadata', 'src'
 
-        #   5.1. remove constexpr form: key, signature, params
+        #   5.1. remove constexpr from: key, signature, params
 
-        def remove_constexpr(key):
+        def remove_constexpr(bwd_jit_fn, key):
             if VERBOSE: print("[remove_constexpr] key: ", key)
             # need to also modify self.signature bc it's used in create_binder -> create_function_from_signature
             #   > inf JITFunction.run "binder = create_function_from_signature(self.signature, self.params, backend)"
-            if VERBOSE: print("[remove_constexpr] fn.jit_function.signature:", fn.jit_function.signature)
-            if VERBOSE: print("[remove_constexpr] fn.jit_function.params:", fn.jit_function.params)
+            if VERBOSE: print("[remove_constexpr] bwd_jit_fn.signature:", bwd_jit_fn.signature)
+            if VERBOSE: print("[remove_constexpr] bwd_jit_fn.params:", bwd_jit_fn.params)
 
             # remove constexpr -- bc backward signature or key should not have them (bc they will NOT be provided to the bwd kernel)
             # remove ", ('constexpr', 4)"
             # key = key.replace(", ('constexpr', 4)", "")
-            # replaces all occurrences of , ('constexpr', [some integer]) in the string
 
+            # replaces all occurrences of , ('constexpr', [some integer]) in the string
             sub_strs = key.split("[")[1].split("]")[0].split("), (")
             # if VERBOSE: print('sub_strs: ', sub_strs)
             # >>> sub_strs:  ["('*fp32', 'D'", "'*fp32', 'D'", "'constexpr', 4", "'*fp32', 'D'", "'*fp32', 'D')"]
@@ -382,18 +384,18 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
                 if i in idx_const_ints:
                     sub_strs.pop(i)
                     sig_params.pop(i)
-                    fn.jit_function.params.pop(i)
+                    bwd_jit_fn.params.pop(i)
             new_key = "[" + "), (".join(sub_strs)
             new_key += "]" if new_key[-1] == ")" else ")]"
             new_key += key.split("]")[1]
             if VERBOSE: print("[remove_constexpr] new_key", new_key)
-            fn.jit_function.signature = fn.jit_function.signature.replace(parameters=sig_params)
-            if VERBOSE: print("[remove_constexpr] fn.jit_function.signature: ", fn.jit_function.signature)
-            if VERBOSE: print("[remove_constexpr] fn.jit_function self.params:", fn.jit_function.params)
+            bwd_jit_fn.signature = bwd_jit_fn.signature.replace(parameters=sig_params)
+            if VERBOSE: print("[remove_constexpr] bwd_jit_fn.signature: ", bwd_jit_fn.signature)
+            if VERBOSE: print("[remove_constexpr] bwd_jit_fn self.params:", bwd_jit_fn.params)
 
             return new_key, num_const_args
 
-        new_key, num_const_args = remove_constexpr(key)
+        new_key, num_const_args = remove_constexpr(bwd_jit_fn, key)
 
         #   5.2. add new args to: key, signature, params
 
@@ -410,7 +412,7 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
         num_bwd_args = len(bwd_compiled_kernel.src.signature)
         num_added_args = num_bwd_args - num_fwd_args
 
-        new_binder = rebuild_binder(fn, num_added_args, backend)
+        new_binder = rebuild_binder(bwd_jit_fn, num_added_args, backend)
         if VERBOSE: print("new_binder: ", new_binder)
 
         if VERBOSE: print("fn.jit_function.signature:", fn.jit_function.signature)
@@ -419,36 +421,27 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
 
         #   5.3. add to bwd CompiledKernel into the cache
 
-        del jit_fn.device_caches[device][0][key]
+        # keep forward cache entry as is, don't delete it
+
         # previously I incorrectly stored at the same key -- so the grad fn is basically keyed on singatures to the fwd kernel
         # key on a new_key (containing added args) not on the old key, otherwise:
-        #   when you pass 6 args to the bwd JITFunction on the next call, it checks the cache for CompiledKernel with signature which has 6 args -- didn't find one (bc here you're storing the bwd CompiledKernel under the *original key* which only has 3 args) and thus re-compiles
+        #   when you pass e.g. 6 args to the bwd JITFunction on the next call, it checks the cache for CompiledKernel with signature which has 6 args -- didn't find one (bc here you're storing the bwd CompiledKernel under the *original key* which only has 3 args) and thus re-compiles
         #   JITFunction looking for key: [('*fp32','D'), … 6 items …]{'debug':False}
-        # IOW
-        #   otherwise re-wraps -- you'd think that it should bc the signature of args taht will be passed to bwd_kernel is the same as was passed to bwd_kernel (just line above) -- so it seems like shouldn't trigger a re-tracing, but in fact, i guess bc I modified function signature in the hook after last re-teacing, it tries to trace again!
-        #   no actually it was re-wrapping bc previously (in my post hook) I saved bwd graph while key'ing on the original signature (3 args). But now when passing 6 args -- it fails to find compiledKerenl with a key which has 6 args and thus re-compiles
-        kernel_cache[new_key] = bwd_compiled_kernel
-        if VERBOSE: print("kernel_cache[new_key]: ", kernel_cache[new_key])
-        fn.jit_function.device_caches[device] = (kernel_cache, target, backend, new_binder)
+        # IOW, it was re-wrapping bc previously (in my post hook) I saved bwd graph while key'ing on the original signature (3 args). But now when passing 6 args -- it fails to find compiledKerenl with a key which has 6 args and thus re-compiles
+        bwd_kernel_cache[new_key] = bwd_compiled_kernel
+        if VERBOSE: print("bwd_kernel_cache[new_key]: ", bwd_kernel_cache[new_key])
+        bwd_jit_fn.device_caches[device] = (bwd_kernel_cache, target, backend, new_binder)
 
-        # s = fn.jit_function # RM
-        # s.device_caches = defaultdict(s.create_binder) # RM
-        # s.device_caches = defaultdict() # RM
-
-        # # question-now: does recomputing them help?
+        # question-now: recomputing them?
         # s.non_constexpr_indices = [i for (i, p) in enumerate(s.params) if not p.is_constexpr] # RM
         # s.specialised_indices = [i for (i, p) in enumerate(s.params) if (not p.do_not_specialize) and (not p.is_constexpr)] # RM
 
-        # todo: Iterate over fn.jit_function.device_caches.keys() and duplicate the backward kernel per device, or error out if torch.cuda.current_device() differs between forward and backward.
+        # todo: Iterate over bwd_jit_fn.device_caches.keys() and duplicate the backward kernel per device, or error out if torch.cuda.current_device() differs between forward and backward.
         # # if multiple gpus, patch caches of all devices?
-        # for d, (cch, t, b, _) in fn.jit_function.device_caches.items():
+        # for d, (cch, t, b, _) in bwd_jit_fn.device_caches.items():
         #     if key in cch:
         #         cch[key] = new_k
-        #         fn.jit_function.device_caches[d] = (cch, t, b, new_binder)
-
-
-        # quick sanity check
-        # assert len(fwd_compiled_kernel.metadata.arg_types) == bwd_compiled_kernel.metadata.arg_types
+        #         bwd_jit_fn.device_caches[d] = (cch, t, b, new_binder)
 
         if VERBOSE: print("[my_hook] compile_dict['signature']", compile_dict["signature"])
         if VERBOSE: print("[my_hook] compile_dict['constants']", compile_dict["constants"])
@@ -457,74 +450,100 @@ def my_post_hook(key, repr, fn, compile, is_manual_warmup, already_compiled):
 
 
         # recover all arguments that have been folded into the CompiledKernel (need for later removal
-        # of these folded args from fwd_kernel_args inside create_bwd_kernel_inputs before passing them bwd_kernel);
+        # of these folded args from fwd_kernel_args inside wrapped_bwd_kernel before passing them bwd_kernel);
         # includes compile‑time constants (declared `constexpr`) AND automatically specialised (ints/bools/tuples …)
         folded = list(p[0] for p in compile_dict["constants"])
         names = [fn.jit_function.arg_names[i] for i in folded]
         if VERBOSE: print("Hard‑coded parameter indices:", sorted(folded))
         if VERBOSE: print("Hard‑coded parameter names:  ", names)
-        fn.jit_function._autodiff_info.append(folded)
+        # todo-now: ugly
+        bwd_jit_fn._autodiff_info.append(folded)
+        print("setting _autodiff_info", bwd_jit_fn._autodiff_info)
 
     return False
 
 
 
+# dont set it inside autograd fn, but rather set it here on module lvl (triggers at import)
+# Bc I'm registering hooks on the fwd JITFucntions -- so I need to register my hook
+# before the first user invocation of fwd JITFucntions (so that my wrapping can see
+# as many fwd signatures as possible)
+triton.runtime.jit.JITFunction.compiled_hook = my_post_hook
 
 
-# double nesting is needed here to support decorator with arguments
-# and I want make user pass the stub here -- bc need some generic way for usr
-# to specify what their stub fn is wt me hardcoding it
-#
+# todo-med: user interface of adding a deco to their stub seems cleaner than having them call a separate callable
 # def grad(stub, idx_upstream):
-
 #     def inner(kernel):
-#         kernel.add_pre_run_hook(shape_track_hook)
-
-#         # todo: add a hook to a specific instance of a JITFunction
-#         # Assign the hook to JITFunction's compiled_hook
-
-#         triton.runtime.jit.JITFunction.compiled_hook = my_post_hook
-#         return kernel
-
+#         return
 #     return inner
+
 
 
 
 class DifferentiatedCompiledKernel(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, stub, create_bwd_kernel_inputs, post_process_fn, *stub_inputs):
+    def forward(ctx, fwd_kernel, wrapped_bwd_kernel, idxs_buffers, grid, *fwd_kernel_inputs):
         if VERBOSE: print("\n"*3, "Op.forward")
 
-        # basically the problem is that for Op.backward you need to save in args produced inside the fwd_stub (can get access right before executing the fwd kernel)
-        #   ==> can overload kernel pre-hook to get access to them
-        with StashArgsCtx() as arg_ctx:
-            # if VERBOSE: print("[op fwd] stub_inputs:", stub_inputs)
-            outs = stub(*stub_inputs)
-        # now executing the stub should populate FWD_ARGS (bc we registered pre-hook on the kernel, and that kernel was called inside the stub)
+        # todo-now:
+        # bc calling the fwd kernel will write output inplace of some original arguments (the
+        # ones which are output buffers) -- but my bwd expects a cleanly initialized buffers
+        #  - clone them and store on the ctx BEFORE they got overwritten by calling the fwd kernel?
+        #  - actually maybe even better: on cpp side remove the entire fwd subgraph leaning the ouput?
+        #    Bc fwd result which I re-compute during bwd will not be used anywhere anyway -- wasted computations
 
-        # todo:
-        # note the execution of the kernel might have over-written zeroed out output buffers (initialized in the stub) with actual kernel outputs
+        if VERBOSE: print("[Op.forward] fwd_kernel_inputs (before calling kernel)", *fwd_kernel_inputs)
+        # calling wrap_bwd_kernel inside AG is also nice because clary separates roles:
+        #   - diff'ing everything what's called inside this AG class (kernel) -- I take care of
+        #   - diff'ing anything outside this class (i.e. stub logic including pre/post processing) -- torch's responsibility
+        # outs = fwd_kernel[grid](*fwd_kernel_inputs)
+        fwd_kernel[grid](*fwd_kernel_inputs)
+        # self.run(grid=grid, warmup=False, *args, **kwargs)
 
-        # note: you assume nothing modifies these arg in the StashArgsCtx before Function.backward is called (between Function.fwd and Function.bwd)
-        kernel_inputs = arg_ctx.args
-        # if VERBOSE: print("saving for bwd: ", kernel_inputs)
-        # if VERBOSE: print("kernel_inputs: ", len(kernel_inputs))
+        if VERBOSE: print("[Op.forward] fwd_kernel_inputs (after calling kernel)", *fwd_kernel_inputs)
 
-        # ugly workaround for the fact that save_for_backward only works for tensor inputs
-        # note stashing kernel inputs, not stub inputs
-        ctx.save_for_backward(*[a for a in kernel_inputs if isinstance(a, torch.Tensor)])
-        # assign to cxt to extract from .backward
-        ctx.non_tensor_inputs = [a for a in kernel_inputs if not isinstance(a, torch.Tensor)]
-        ctx.arg_types = [isinstance(a, torch.Tensor) for a in kernel_inputs]
+        # input a list of idx_buffer_args -- from user so that here you'd use it for mark_dirty
+        # and in AG.backward you can return none wrt all of them
+        for i in idxs_buffers:
+            ctx.mark_dirty(fwd_kernel_inputs[i])
 
-        ctx.create_bwd_kernel_inputs = create_bwd_kernel_inputs
-        ctx.post_process_fn = post_process_fn
-        return outs
+        # if VERBOSE: print("saving for bwd: ", fwd_kernel_inputs)
+        # ugly workaround because save_for_backward only works for tensor inputs
+        tensor_fwd_kernel_inputs = [a for a in fwd_kernel_inputs if isinstance(a, torch.Tensor)]
+        ctx.save_for_backward(*tensor_fwd_kernel_inputs)
+        ctx.non_tensor_inputs = [a for a in fwd_kernel_inputs if not isinstance(a, torch.Tensor)]
+        ctx.arg_types = [isinstance(a, torch.Tensor) for a in fwd_kernel_inputs]
+        ctx.idxs_buffers = idxs_buffers
+
+        ctx.wrapped_bwd_kernel = wrapped_bwd_kernel
+        ctx.grid = grid
+
+        # need to return values from AG.fwd, even though caller discards output of this fn ("kernel[...]" -- the result is not assigned by the caller)
+        #
+        # i think: When the engine attaches grad_fn to the returned tensor it also sets
+        #   requires_grad=True automatically if any upstream input in the graph needs
+        #   gradients. So the buffer now participates in back-prop exactly as a normal
+        #   output would, even though Python code in the stub (caller of this Autograd.forward)
+        #   discards the return value
+        #
+        # return only tensor inputs I guess -- bc for everything I return here, I believe torch will try
+        #   to attached "grad_fn=DifferentiatedCompiledKernel" -- which wouldn't make sense for non
+        #   tensor args (e.g. BLOCK_SIZE=4 kwargs to the kernel)
+        return (*tensor_fwd_kernel_inputs, )
 
 
     @staticmethod
-    def backward(ctx, upstream):
+    def backward(ctx, *all_upstream):
+
+        # because in AG.fwd I'm returning ALL the kernel tensor args, in the AG.bwd,
+        # I need to input grads wrt ALL OF THEM -- not just grad wrt the single
+        # output returned form the user stub;
+        # AG.bwd expects same num of args (upstream grads) as the outputs of
+        # AG.fwd -- so here select upstream of the actual output of the kernel:
+        upstream_idx = 1
+        upstream = all_upstream[upstream_idx]
+
         if VERBOSE: print("\n"*3, "Op.backward")
 
         # reconstruct all fwd kernel args
@@ -539,34 +558,78 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
                 fwd_kernel_inputs.append(ctx.non_tensor_inputs[non_tensor_idx])
                 non_tensor_idx += 1
 
-        # IOW: create_grad_inputs
-        # if VERBOSE: print("[Op.backward] fwd_kernel_inputs", fwd_kernel_inputs)
-        grads = ctx.create_bwd_kernel_inputs(fwd_kernel_inputs, upstream)
-        # if VERBOSE: print("[Op.backward] grads", grads)
+        # todo-now: note output buffers (in this case at idx=1) have my grad_fn attached -- but in AG.bwd I'll be runnign kernel on them again: undesirable?
+        if VERBOSE: print("[Op.backward] reconstructed fwd_kernel_inputs", fwd_kernel_inputs)
+        # > tensor([...], device='cuda:0', requires_grad=True),
+        # > tensor([...], device='cuda:0', grad_fn=<DifferentiatedCompiledKernelBackward>)]
 
-        if ctx.post_process_fn is not None:
-            grads = ctx.post_process_fn(*grads)
+        # wrapped_bwd_kernel does return grad_inputs that it initialized, after running the
+        # generated_bwd_kernel these are populated -- and contain grads wrt original tensor inputs
+        grads = ctx.wrapped_bwd_kernel(ctx.idxs_buffers, ctx.grid, fwd_kernel_inputs, upstream)
+        if VERBOSE: print("[Op.backward] grads", grads)
 
-        return (None, None, None, *grads,)
+        # at this point your "grads" value has grads wrt args of fwd kernel (including grad wrt kernel out itself
+        # -- not popping it in wrap_bwd_kernel because here I'm required to return grads wrt ALL inputs which passed to AG.fwd)
+        return (None, None, None,  None, *grads,)
 
 
 
-def autodiff(kernel, stub, grid, idx_upstream, non_stub_args_idxs=None, post_process_fn=None):
 
-    if non_stub_args_idxs is None:
-        non_stub_args_idxs = []
 
-    global bwd_kernel
-    bwd_kernel = clone_jit_function(kernel)
+def autodiff(fwd_kernel, stub, idx_upstream, idxs_buffers=None):
 
-    kernel.add_pre_run_hook(shape_track_hook)
-    triton.runtime.jit.JITFunction.compiled_hook = my_post_hook
 
-    global create_bwd_kernel_inputs
-    create_bwd_kernel_inputs = partial(create_bwd_kernel_inputs, bwd_kernel, idx_upstream, grid, non_stub_args_idxs)
-    fwd_stub = partial(stub, kernel)
-    my_op = partial(DifferentiatedCompiledKernel.apply, fwd_stub, create_bwd_kernel_inputs, post_process_fn)
-    return my_op, bwd_kernel
+    def make_indexable(fn):
+        class Indexable:
+            def __getitem__(self, grid):
+                return lambda *args, **kwargs: fn(grid, *args, *kwargs)
+                # # below is needed for debugging:
+                # def wrapper(*args, **kwargs):
+                #     out = fn(grid, *args, *kwargs)
+                #     for o in out:
+                #         print("[Indexable] o.grad_fn", o) # o.grad_fn)
+                #     # note returns nothing -- as regular triton kernels do
+                # return wrapper
+        return Indexable()
+
+
+
+    # make my assumption explicit (same as api-v2)
+    assert isinstance(idx_upstream, int), "idx_upstream must be a single value"
+
+    bwd_kernel = clone_jit_function(fwd_kernel) # new object, empty cache
+
+    # device = torch.cuda.current_device()
+    # print("[autodiff] bwd_kernel cache:", bwd_kernel.device_caches[device][0])
+
+    # allows to associate a bwd JITFcuntion with this specific fwdKernel
+    # so that, from inside the compile hook (which will be triggered on the fwd JITFunciton)
+    # I can install the bwd CompiledKernel **on the backward JITFcuntion** (NOT fwd JITFcuntion)
+    fwd_kernel._bwd_kernel = bwd_kernel
+
+    # I'm registering compile hook on all JITFunction[s] (both forward and backward);
+    # this flag is needed to be able to early exit from the hook (avoids triggering
+    # the autograd machinery on already differentiated kernels)
+    fwd_kernel._is_fwd_kernel = True
+
+    # idxs_buffers includes but not limited to idx_upstream -- see e.g. layer-norm example;
+    #
+    # todo-high: can determine automatically:
+    #   - in AG.fwd -- run kernel once and see which inputs were changed as result of executing kernel;
+    #   - Or, in mlir pass output idx of all inputs which are used in store nodes
+    if idxs_buffers is None:
+        idxs_buffers = []
+    idxs_buffers.append(idx_upstream)
+
+    wrapped_bwd_kernel = partial(wrap_bwd_kernel, fwd_kernel, bwd_kernel, idx_upstream)
+
+    my_op = partial(DifferentiatedCompiledKernel.apply, fwd_kernel, wrapped_bwd_kernel, idxs_buffers)
+
+    # avoid user needing to pass grid parameter explicitly
+    # because wrapped_bwd_kernel will called from inside the user stub inplace of the original
+    # kernel -- it will be called like so "wrapped_bwd_kernel[grid](...)";
+    # make_indexable is needed to enable wrapped_bwd_kernel support this calling convention
+    return make_indexable(my_op)
 
 
 

--- a/third_party/autodiff/python/api.py
+++ b/third_party/autodiff/python/api.py
@@ -483,8 +483,11 @@ triton.runtime.jit.JITFunction.compiled_hook = my_post_hook
 class DifferentiatedCompiledKernel(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, fwd_kernel, wrapped_bwd_kernel, idxs_buffers, grid, *fwd_kernel_inputs):
+    def forward(ctx, kernels, idxs, grid, *fwd_kernel_inputs):
         if VERBOSE: print("\n"*3, "Op.forward")
+
+        fwd_kernel, wrapped_bwd_kernel = kernels
+        idx_upstream, idxs_buffers = idxs
 
         # todo-now:
         # bc calling the fwd kernel will write output inplace of some original arguments (the
@@ -514,7 +517,9 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
         ctx.save_for_backward(*tensor_fwd_kernel_inputs)
         ctx.non_tensor_inputs = [a for a in fwd_kernel_inputs if not isinstance(a, torch.Tensor)]
         ctx.arg_types = [isinstance(a, torch.Tensor) for a in fwd_kernel_inputs]
+
         ctx.idxs_buffers = idxs_buffers
+        ctx.idx_upstream = idx_upstream
 
         ctx.wrapped_bwd_kernel = wrapped_bwd_kernel
         ctx.grid = grid
@@ -541,8 +546,7 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
         # output returned form the user stub;
         # AG.bwd expects same num of args (upstream grads) as the outputs of
         # AG.fwd -- so here select upstream of the actual output of the kernel:
-        upstream_idx = 1
-        upstream = all_upstream[upstream_idx]
+        upstream = all_upstream[ctx.idx_upstream]
 
         if VERBOSE: print("\n"*3, "Op.backward")
 
@@ -570,7 +574,7 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
 
         # at this point your "grads" value has grads wrt args of fwd kernel (including grad wrt kernel out itself
         # -- not popping it in wrap_bwd_kernel because here I'm required to return grads wrt ALL inputs which passed to AG.fwd)
-        return (None, None, None,  None, *grads,)
+        return (None, None, None, *grads,)
 
 
 
@@ -593,11 +597,11 @@ def autodiff(fwd_kernel, stub, idx_upstream, idxs_buffers=None):
         return Indexable()
 
 
-
     # make my assumption explicit (same as api-v2)
     assert isinstance(idx_upstream, int), "idx_upstream must be a single value"
 
-    bwd_kernel = clone_jit_function(fwd_kernel) # new object, empty cache
+    # new object, empty cache -- each JITFunction instance owns its own device_caches dict
+    bwd_kernel = clone_jit_function(fwd_kernel)
 
     # device = torch.cuda.current_device()
     # print("[autodiff] bwd_kernel cache:", bwd_kernel.device_caches[device][0])
@@ -623,7 +627,9 @@ def autodiff(fwd_kernel, stub, idx_upstream, idxs_buffers=None):
 
     wrapped_bwd_kernel = partial(wrap_bwd_kernel, fwd_kernel, bwd_kernel, idx_upstream)
 
-    my_op = partial(DifferentiatedCompiledKernel.apply, fwd_kernel, wrapped_bwd_kernel, idxs_buffers)
+    kernels = (fwd_kernel, wrapped_bwd_kernel)
+    idxs = (idx_upstream, idxs_buffers)
+    my_op = partial(DifferentiatedCompiledKernel.apply, kernels, idxs)
 
     # avoid user needing to pass grid parameter explicitly
     # because wrapped_bwd_kernel will called from inside the user stub inplace of the original

--- a/third_party/autodiff/python/api.py
+++ b/third_party/autodiff/python/api.py
@@ -2,9 +2,9 @@ import sys
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 import hashlib
+import inspect
 import subprocess
 from functools import partial
-from collections import defaultdict
 
 import torch
 torch.manual_seed(0)
@@ -112,7 +112,7 @@ def clone_jit_function(jit_func):
     return cloned
 
 # it's not as much as a stub, but more like helper to wrap_bwd_kernel from kernel_inputs -- the true stub is the user thing, this thing just piggy backs on the true stub
-def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, grid, kernel_inputs, upstream):
+def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, kernel_inputs, upstream):
 
 
     # # todo: understand more
@@ -179,7 +179,7 @@ def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, grid, ke
     if VERBOSE: print("[wrap_bwd_kernel] fwd_args:", kernel_inputs)
     if VERBOSE: print("[wrap_bwd_kernel] bwd_args:", bwd_args)
 
-    bwd_kernel[grid](*kernel_inputs, *bwd_args)
+    bwd_kernel[(1,)](*kernel_inputs, *bwd_args)
     # bwd_kernel.run(grid=grid, warmup=False, *kernel_inputs, *bwd_args)
 
     print("[wrap_bwd_kernel] bwd_args (after calling bwd_kernel): ", bwd_args)
@@ -483,8 +483,10 @@ triton.runtime.jit.JITFunction.compiled_hook = my_post_hook
 class DifferentiatedCompiledKernel(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, kernels, idxs, grid, *fwd_kernel_inputs):
+    def forward(ctx, kernels, idxs, *fwd_kernel_inputs): # , grid
         if VERBOSE: print("\n"*3, "Op.forward")
+
+        grid = (1, )
 
         fwd_kernel, wrapped_bwd_kernel = kernels
         idx_upstream, idxs_buffers = idxs
@@ -569,12 +571,13 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
 
         # wrapped_bwd_kernel does return grad_inputs that it initialized, after running the
         # generated_bwd_kernel these are populated -- and contain grads wrt original tensor inputs
-        grads = ctx.wrapped_bwd_kernel(ctx.idxs_buffers, ctx.grid, fwd_kernel_inputs, upstream)
+        grads = ctx.wrapped_bwd_kernel(ctx.idxs_buffers, fwd_kernel_inputs, upstream) # ctx.grid, 
         if VERBOSE: print("[Op.backward] grads", grads)
 
         # at this point your "grads" value has grads wrt args of fwd kernel (including grad wrt kernel out itself
         # -- not popping it in wrap_bwd_kernel because here I'm required to return grads wrt ALL inputs which passed to AG.fwd)
-        return (None, None, None, *grads,)
+        # todo-now: need to return grad for non tensor inputs
+        return (None, None, *grads, None)
 
 
 
@@ -582,18 +585,46 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
 
 def autodiff(fwd_kernel, stub, idx_upstream, idxs_buffers=None):
 
+    def kwargify(AutogradFunc, spec=None):
+        # returns a subclass of `AutogradFunc` whose .apply accepts keywords
+        # AutogradFunc.forward stays (ctx, *args, **kwargs) -- fine as long as it can consume the ordered list I pass in
+
+        target_sig = inspect.signature(spec)
+        print("[kwargify] target_sig", target_sig)
+        params = target_sig.parameters.values()
+        print("[kwargify] params", params)
+
+        class _Kwargify(AutogradFunc):
+            # __signature__ = target_sig          # IDE/help friendly
+            __doc__       = AutogradFunc.__doc__
+            __name__      = AutogradFunc.__name__
+            __qualname__  = AutogradFunc.__qualname__
+
+            # todo-now: add args to sig for: kernels, idxs, grid
+            @classmethod
+            def apply(cls, kernels, idxs, *args, **kwargs): # grid, 
+                print("[_Kwargify.apply] args", args)
+                print("[_Kwargify.apply] kwargs", kwargs)
+                # print("[_Kwargify.apply] grid", grid)
+                bound = target_sig.bind_partial(*args, **kwargs)
+                bound.apply_defaults()
+                # fixed positional order for c++ apply
+                ordered = [bound.arguments[p.name] for p in params]
+                return super().apply(kernels, idxs, *ordered) # grid,
+
+        return _Kwargify
 
     def make_indexable(fn):
         class Indexable:
             def __getitem__(self, grid):
-                return lambda *args, **kwargs: fn(grid, *args, *kwargs)
-                # # below is needed for debugging:
-                # def wrapper(*args, **kwargs):
-                #     out = fn(grid, *args, *kwargs)
-                #     for o in out:
-                #         print("[Indexable] o.grad_fn", o) # o.grad_fn)
-                #     # note returns nothing -- as regular triton kernels do
-                # return wrapper
+                # return lambda *args, **kwargs: fn(grid, [*args, kwargs])
+                # below is needed for debugging:
+                def wrapper(*args, **kwargs):
+                    out = fn(grid, *args, **kwargs)
+                    for o in out:
+                        print("[Indexable] o.grad_fn", o) # o.grad_fn)
+                    # note returns nothing -- as regular triton kernels do
+                return wrapper
         return Indexable()
 
 
@@ -627,15 +658,21 @@ def autodiff(fwd_kernel, stub, idx_upstream, idxs_buffers=None):
 
     wrapped_bwd_kernel = partial(wrap_bwd_kernel, fwd_kernel, bwd_kernel, idx_upstream)
 
+    # takes the signature form fwd_kernel's python fn
+    kwargified_op = kwargify(DifferentiatedCompiledKernel, fwd_kernel.fn)
+
     kernels = (fwd_kernel, wrapped_bwd_kernel)
     idxs = (idx_upstream, idxs_buffers)
-    my_op = partial(DifferentiatedCompiledKernel.apply, kernels, idxs)
+    op = partial(kwargified_op.apply, kernels, idxs)
 
     # avoid user needing to pass grid parameter explicitly
     # because wrapped_bwd_kernel will called from inside the user stub inplace of the original
     # kernel -- it will be called like so "wrapped_bwd_kernel[grid](...)";
     # make_indexable is needed to enable wrapped_bwd_kernel support this calling convention
-    return make_indexable(my_op)
+    # return make_indexable(op)
+    return op
+
+
 
 
 

--- a/third_party/autodiff/python/api.py
+++ b/third_party/autodiff/python/api.py
@@ -112,7 +112,7 @@ def clone_jit_function(jit_func):
     return cloned
 
 # it's not as much as a stub, but more like helper to wrap_bwd_kernel from kernel_inputs -- the true stub is the user thing, this thing just piggy backs on the true stub
-def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, grid, kernel_inputs, upstream):
+def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, grid, kernel_inputs, all_upstream):
 
 
     # # todo: understand more
@@ -163,9 +163,17 @@ def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, grid, ke
     # if VERBOSE: print("[wrap_bwd_kernel] idx_folded", idx_folded)
     # if VERBOSE: print("num_folded_before_upstream:", num_folded_before_upstream)
 
+    # because in AG.fwd I'm returning ALL the kernel tensor args, in the AG.bwd,
+    # I need to input grads wrt ALL OF THEM -- not just grad wrt the single
+    # output returned form the user stub;
+    # AG.bwd expects same num of args (upstream grads) as the outputs of
+    # AG.fwd -- so here select upstream of the actual output of the kernel:
+    idx_upstream -= num_folded_before_upstream
+    upstream = all_upstream[idx_upstream]
+
     bwd_args = []
     for i, arg in enumerate(kernel_inputs):
-        if i == (idx_upstream - num_folded_before_upstream):
+        if i == idx_upstream:
             bwd_args.append(upstream)
             continue
         if isinstance(arg, torch.Tensor):
@@ -182,7 +190,7 @@ def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, grid, ke
     bwd_kernel[grid](*kernel_inputs, *bwd_args)
     # bwd_kernel.run(grid=grid, warmup=False, *kernel_inputs, *bwd_args)
 
-    print("[wrap_bwd_kernel] bwd_args (after calling bwd_kernel): ", bwd_args)
+    if VERBOSE: print("[wrap_bwd_kernel] bwd_args (after calling bwd_kernel): ", bwd_args)
 
     # don't need to pop grad wrt upstream anymore bc now (when my AG.Function works on lvl of kernels, but not stubs)
     # I actually do need to return grads wrt each of the inputs of the kernel inputs (including the out buffers):
@@ -209,9 +217,6 @@ def wrap_bwd_kernel(fwd_kernel, bwd_kernel, idx_upstream, idxs_buffers, grid, ke
     # #     # shift them by 1 to account for the grad_out that I popped just above
     # #     bwd_args.pop(i) if i < idx_upstream else bwd_args.pop(i - 1)
 
-    print("[wrap_bwd_kernel] returning", bwd_args)
-
-    # unpack
     return (*bwd_args,)
 
 
@@ -541,13 +546,6 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
     @staticmethod
     def backward(ctx, *all_upstream):
 
-        # because in AG.fwd I'm returning ALL the kernel tensor args, in the AG.bwd,
-        # I need to input grads wrt ALL OF THEM -- not just grad wrt the single
-        # output returned form the user stub;
-        # AG.bwd expects same num of args (upstream grads) as the outputs of
-        # AG.fwd -- so here select upstream of the actual output of the kernel:
-        upstream = all_upstream[ctx.idx_upstream]
-
         if VERBOSE: print("\n"*3, "Op.backward")
 
         # reconstruct all fwd kernel args
@@ -569,13 +567,21 @@ class DifferentiatedCompiledKernel(torch.autograd.Function):
 
         # wrapped_bwd_kernel does return grad_inputs that it initialized, after running the
         # generated_bwd_kernel these are populated -- and contain grads wrt original tensor inputs
-        grads = ctx.wrapped_bwd_kernel(ctx.idxs_buffers, ctx.grid, fwd_kernel_inputs, upstream) # ctx.grid, 
+        grads = ctx.wrapped_bwd_kernel(ctx.idxs_buffers, ctx.grid, fwd_kernel_inputs, all_upstream)
         if VERBOSE: print("[Op.backward] grads", grads)
 
         # at this point your "grads" value has grads wrt args of fwd kernel (including grad wrt kernel out itself
         # -- not popping it in wrap_bwd_kernel because here I'm required to return grads wrt ALL inputs which passed to AG.fwd)
-        # todo-now: need to return grad for non tensor inputs
-        return (None, None, None, *grads, None)
+        all_outs = []
+        tensor_idx = 0
+        for i, is_tensor in enumerate(ctx.arg_types):
+            if is_tensor:
+                all_outs.append(grads[tensor_idx])
+                tensor_idx += 1
+            else:
+                all_outs.append(None)
+
+        return (None, None, None, *all_outs, )
 
 
 
@@ -600,7 +606,7 @@ def autodiff(fwd_kernel, stub, idx_upstream, idxs_buffers=None):
 
             @classmethod
             def apply(cls, *args, **kwargs):
-                if VERBOSE: print("[_Helper.apply] args", args)
+                # if VERBOSE: print("[_Helper.apply] args", args)
                 if VERBOSE: print("[_Helper.apply] kwargs", kwargs)
                 # if VERBOSE: print("[_Helper.apply] grid", cls.grid)
                 bound = target_sig.bind_partial(*args, **kwargs)

--- a/third_party/autodiff/python/api.py
+++ b/third_party/autodiff/python/api.py
@@ -669,14 +669,3 @@ def autodiff(fwd_kernel, stub, idx_upstream, idxs_buffers=None):
     # make_indexable is needed to enable wrapped_bwd_kernel support this calling convention
     # return make_indexable(op)
     return op
-
-
-
-
-
-#### utils  ####
-
-from functools import partial
-
-def right_partial(func, *args):
-    return lambda *fargs: func(*fargs, *args)

--- a/third_party/autodiff/test/2d_dot/run.py
+++ b/third_party/autodiff/test/2d_dot/run.py
@@ -1,12 +1,13 @@
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
-
 import torch
-
 import triton
 import triton.language as tl
 
+from triton.backends.autodiff import autodiff
+
+torch.manual_seed(0)
 DEVICE = torch.device("cuda:0")
 
 
@@ -33,7 +34,9 @@ def stub(kernel, a, b):
     kernel[grid](a, b, output) # BLOCK_SIZE=4
     return output
 
-torch.manual_seed(0)
+my_op = autodiff(kernel, stub, idx_upstream=2)
+
+
 # fits in a single block -- less complex kernel (and thus the IR) bc not computing idx using block_size and pid in this case;
 # Also, bc it's exactly the size of the block -- no need to add masks when loading -- further simplifies loading
 size = 16
@@ -47,7 +50,7 @@ def torch_fn(a, b):
 #### test forward ####
 
 output_torch = torch_fn(a, b)
-output_triton = stub(kernel, a, b)
+output_triton = stub(my_op, a, b)
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 
 # print("output_torch:", output_torch[:3, :3])
@@ -68,13 +71,7 @@ upstream = torch.randn_like(output_torch)
 a.requires_grad = True
 b.requires_grad = True
 
-from triton.backends.autodiff import autodiff
-
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(1,), idx_upstream=2)
-
-# todo: rm warmup
-stub(bwd_kernel, a, b)
-my_out = my_op(a, b)
+my_out = stub(my_op, a, b)
 my_out.backward(upstream)
 print("grad a[:3, :3]: ", a.grad[:3, :3])
 print("grad b[:3, :3]: ", b.grad[:3, :3])

--- a/third_party/autodiff/test/add-mul-div/run.py
+++ b/third_party/autodiff/test/add-mul-div/run.py
@@ -1,12 +1,13 @@
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
-
 import torch
-
 import triton
 import triton.language as tl
 
+from triton.backends.autodiff import autodiff
+
+torch.manual_seed(0)
 DEVICE = torch.device("cuda:0")
 
 
@@ -35,7 +36,8 @@ def stub(kernel, a, b, c):
     kernel[grid](a, b, c, output)
     return output
 
-torch.manual_seed(0)
+my_op = autodiff(kernel, stub, idx_upstream=3)
+
 size = 4
 a = torch.rand(size, device=DEVICE)
 b = torch.rand(size, device=DEVICE)
@@ -48,7 +50,7 @@ def torch_fn(a, b, c):
     return z
 
 output_torch = torch_fn(a, b, c)
-output_triton = stub(kernel, a, b, c)
+output_triton = stub(my_op, a, b, c)
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 
 # print(output_torch)
@@ -63,8 +65,6 @@ else:
     print("❌ Triton and Torch differ")
 
 
-
-
 #### test backward ####
 
 upstream = torch.randn_like(a)
@@ -72,14 +72,7 @@ a.requires_grad = True
 b.requires_grad = True
 c.requires_grad = True
 
-from triton.backends.autodiff import autodiff
-
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(1,), idx_upstream=3)
-
-# todo: rm warmup
-stub(bwd_kernel, a, b, c)
-
-my_out = my_op(a, b, c)
+my_out = stub(my_op, a, b, c)
 my_out.backward(upstream)
 
 

--- a/third_party/autodiff/test/add-mul/run.py
+++ b/third_party/autodiff/test/add-mul/run.py
@@ -1,12 +1,13 @@
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
-
 import torch
-
 import triton
 import triton.language as tl
 
+from triton.backends.autodiff import autodiff
+
+torch.manual_seed(0)
 DEVICE = torch.device("cuda:0")
 
 
@@ -27,15 +28,21 @@ def kernel(
 
     tl.store(output_ptr + offsets, y, mask=offsets<4)
 
-def stub(kernel, a, b):
+def stub(kernel, a, b, BLOCK_SIZE=4):
     output = torch.empty_like(a)
     assert a.device == DEVICE and output.device == DEVICE
     n_elements = output.numel()
-    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), )
+
+    # todo: support meta
+    # grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), )
+
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE), )
     kernel[grid](a, b, output, BLOCK_SIZE=4)
     return output
 
-torch.manual_seed(0)
+
+my_op = autodiff(kernel, stub, idx_upstream=2)
+
 size = 4
 a = torch.rand(size, device=DEVICE)
 b = torch.rand(size, device=DEVICE)
@@ -44,7 +51,7 @@ def torch_fn(a, b):
     return (a + 0.5) * b
 
 output_torch = torch_fn(a, b)
-output_triton = stub(kernel, a, b)
+output_triton = stub(my_op, a, b)
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 
 # print(output_torch)
@@ -67,15 +74,7 @@ upstream = torch.randn_like(a)
 a.requires_grad = True
 b.requires_grad = True
 
-from triton.backends.autodiff import autodiff
-
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(1,), idx_upstream=2)
-
-# todo: rm warmup
-stub(bwd_kernel, a, b)
-
-
-my_out = my_op(a, b)
+my_out = stub(my_op, a, b)
 my_out.backward(upstream)
 print("grad a: ", a.grad)
 print("grad b: ", b.grad)

--- a/third_party/autodiff/test/add/run.py
+++ b/third_party/autodiff/test/add/run.py
@@ -1,3 +1,5 @@
+from triton.backends.autodiff import autodiff
+
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
@@ -14,10 +16,11 @@ DEVICE = torch.device("cuda:0")
 def kernel(
         x_ptr,  # *Pointer* to first input vector.
         output_ptr,  # *Pointer* to output vector.
-        BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
+        # BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
         # NOTE: `constexpr` so it can be used as a shape value.
     ):
-    offsets = tl.arange(0, BLOCK_SIZE)
+    # offsets = tl.arange(0, BLOCK_SIZE)
+    offsets = tl.arange(0, 4)
     # Load x and y from DRAM, masking out any extra elements in case the input is not a multiple of the block size.
     x = tl.load(x_ptr + offsets)
     output = x + 42
@@ -32,15 +35,27 @@ def stub(kernel, x):
     # The SPMD launch grid denotes the number of kernel instances that run in parallel.
     # It is analogous to CUDA launch grids. It can be either Tuple[int], or Callable(metaparameters) -> Tuple[int].
     # In this case, we use a 1D grid where the size is the number of blocks:
-    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), )
+    # todo-now: support grid lambda fns
+    # grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), )
+    grid = (triton.cdiv(n_elements, 4), )
     # NOTE:
     #  - Each torch.tensor object is implicitly converted into a pointer to its first element.
     #  - `triton.jit`'ed functions can be indexed with a launch grid to obtain a callable GPU kernel.
     #  - Don't forget to pass meta-parameters as keywords arguments.
-    kernel[grid](x, output, BLOCK_SIZE=4)
+    # todo-now: support pasing ", BLOCK_SIZE=4"
+    kernel[grid](x, output)
     # We return a handle to z but, since `torch.cuda.synchronize()` hasn't been called, the kernel is still
     # running asynchronously at this point.
+
+    print("[usr stub] output", output)
     return output
+
+
+device = torch.cuda.current_device()
+print("[main] fwd_kernel cache:", kernel.device_caches[device][0])
+
+
+my_op = autodiff(kernel, stub, idx_upstream=1)
 
 
 # fits in a single block -- less complex kernel (and thus the IR) bc not computing idx using block_size and pid in this case;
@@ -52,9 +67,12 @@ def torch_fn(a):
     return a + 42
 
 output_torch = torch_fn(a)
-output_triton = stub(kernel, a)
+output_triton = stub(my_op, a)
 # print(output_torch)
 # print(output_triton)
+
+print("torch", output_torch)
+print("trition", output_triton)
 
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 # print(f'The maximum difference between torch and triton is '
@@ -72,15 +90,15 @@ else:
 upstream = torch.randn(4, device=DEVICE)
 a.requires_grad = True
 
-from triton.backends.autodiff import autodiff
 
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(1,), idx_upstream=1)
 
-# todo: rm warmup
-print("\n" * 3, "bwd_kernel warmup")
-stub(bwd_kernel, a)
 
-my_out = my_op(a)
+# # todo: rm warmup
+# print("\n" * 3, "bwd_kernel warmup")
+# stub(bwd_kernel, a)
+
+my_out = stub(my_op, a)
+print("my_out.grad_fn", my_out.grad_fn)
 my_out.backward(upstream)
 print("grad a: ", a.grad)
 print()

--- a/third_party/autodiff/test/add/run.py
+++ b/third_party/autodiff/test/add/run.py
@@ -2,12 +2,12 @@ import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
 import torch
-torch.manual_seed(0)
-
 import triton
 import triton.language as tl
+
 from triton.backends.autodiff import autodiff
 
+torch.manual_seed(0)
 DEVICE = torch.device("cuda:0")
 
 
@@ -47,8 +47,8 @@ def stub(kernel, x):
     print("[usr stub] output", output)
     return output
 
-my_op = autodiff(kernel, stub, idx_upstream=1)
 
+my_op = autodiff(kernel, stub, idx_upstream=1)
 
 # fits in a single block -- less complex kernel (and thus the IR) bc not computing idx using block_size and pid in this case;
 # Also, bc it's exactly the size of the block -- no need to add masks when loading -- further simplifies loading
@@ -78,12 +78,10 @@ else:
 
 #### test backward ####
 
-
 upstream = torch.randn(4, device=DEVICE)
 a.requires_grad = True
 
 my_out = stub(my_op, a)
-# print("my_out.grad_fn", my_out.grad_fn)
 my_out.backward(upstream)
 print("grad a: ", a.grad)
 print()

--- a/third_party/autodiff/test/add/run.py
+++ b/third_party/autodiff/test/add/run.py
@@ -1,5 +1,3 @@
-from triton.backends.autodiff import autodiff
-
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
@@ -8,6 +6,7 @@ torch.manual_seed(0)
 
 import triton
 import triton.language as tl
+from triton.backends.autodiff import autodiff
 
 DEVICE = torch.device("cuda:0")
 
@@ -50,11 +49,6 @@ def stub(kernel, x):
     print("[usr stub] output", output)
     return output
 
-
-device = torch.cuda.current_device()
-print("[main] fwd_kernel cache:", kernel.device_caches[device][0])
-
-
 my_op = autodiff(kernel, stub, idx_upstream=1)
 
 
@@ -90,15 +84,8 @@ else:
 upstream = torch.randn(4, device=DEVICE)
 a.requires_grad = True
 
-
-
-
-# # todo: rm warmup
-# print("\n" * 3, "bwd_kernel warmup")
-# stub(bwd_kernel, a)
-
 my_out = stub(my_op, a)
-print("my_out.grad_fn", my_out.grad_fn)
+# print("my_out.grad_fn", my_out.grad_fn)
 my_out.backward(upstream)
 print("grad a: ", a.grad)
 print()

--- a/third_party/autodiff/test/add/run.py
+++ b/third_party/autodiff/test/add/run.py
@@ -15,11 +15,10 @@ DEVICE = torch.device("cuda:0")
 def kernel(
         x_ptr,  # *Pointer* to first input vector.
         output_ptr,  # *Pointer* to output vector.
-        # BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
+        BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
         # NOTE: `constexpr` so it can be used as a shape value.
     ):
-    # offsets = tl.arange(0, BLOCK_SIZE)
-    offsets = tl.arange(0, 4)
+    offsets = tl.arange(0, BLOCK_SIZE)
     # Load x and y from DRAM, masking out any extra elements in case the input is not a multiple of the block size.
     x = tl.load(x_ptr + offsets)
     output = x + 42
@@ -41,8 +40,8 @@ def stub(kernel, x):
     #  - Each torch.tensor object is implicitly converted into a pointer to its first element.
     #  - `triton.jit`'ed functions can be indexed with a launch grid to obtain a callable GPU kernel.
     #  - Don't forget to pass meta-parameters as keywords arguments.
-    # todo-now: support pasing ", BLOCK_SIZE=4"
-    kernel[grid](x, output)
+    # kernel[grid](x, output, BLOCK_SIZE=4)
+    kernel(x, output, BLOCK_SIZE=4)
     # We return a handle to z but, since `torch.cuda.synchronize()` hasn't been called, the kernel is still
     # running asynchronously at this point.
 

--- a/third_party/autodiff/test/add/run.py
+++ b/third_party/autodiff/test/add/run.py
@@ -40,8 +40,7 @@ def stub(kernel, x):
     #  - Each torch.tensor object is implicitly converted into a pointer to its first element.
     #  - `triton.jit`'ed functions can be indexed with a launch grid to obtain a callable GPU kernel.
     #  - Don't forget to pass meta-parameters as keywords arguments.
-    # kernel[grid](x, output, BLOCK_SIZE=4)
-    kernel(x, output, BLOCK_SIZE=4)
+    kernel[grid](x, output, BLOCK_SIZE=4)
     # We return a handle to z but, since `torch.cuda.synchronize()` hasn't been called, the kernel is still
     # running asynchronously at this point.
 

--- a/third_party/autodiff/test/div/run.py
+++ b/third_party/autodiff/test/div/run.py
@@ -1,13 +1,15 @@
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
-
 import torch
-
 import triton
 import triton.language as tl
 
+from triton.backends.autodiff import autodiff
+
+
 DEVICE = torch.device("cuda:0")
+torch.manual_seed(0)
 
 
 @triton.jit
@@ -26,13 +28,16 @@ def kernel(
 
     tl.store(output_ptr + offsets, z)
 
-def stub(kernel, a, b):
+def stub(kernel, a, b, BLOCK_SIZE=4):
     output = torch.empty_like(a)
-    grid = lambda meta: (triton.cdiv(output.numel(), meta['BLOCK_SIZE']), )
+    # todo: support meta
+    # grid = lambda meta: (triton.cdiv(output.numel(), meta['BLOCK_SIZE']), )
+    grid = (triton.cdiv(output.numel(), BLOCK_SIZE), )
     kernel[grid](a, b, output, BLOCK_SIZE=4)
     return output
 
-torch.manual_seed(0)
+my_op = autodiff(kernel, stub, idx_upstream=2)
+
 size = 4
 a = torch.rand(size, device=DEVICE)
 b = torch.rand(size, device=DEVICE)
@@ -43,8 +48,8 @@ b = torch.rand(size, device=DEVICE)
 def torch_fn(a, b):
     return a / b
 
-output_torch =  torch_fn(a, b)
-output_triton = stub(kernel, a, b)
+output_torch = torch_fn(a, b)
+output_triton = stub(my_op, a, b)
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 
 # print(output_torch)
@@ -66,14 +71,7 @@ upstream = torch.randn_like(a)
 a.requires_grad = True
 b.requires_grad = True
 
-from triton.backends.autodiff import autodiff
-
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(1,), idx_upstream=2)
-
-# todo: rm warmup
-stub(bwd_kernel, a, b)
-
-my_out = my_op(a, b)
+my_out = stub(my_op, a, b)
 my_out.backward(upstream)
 # print("grad a: ", a.grad)
 # print("grad b: ", b.grad)

--- a/third_party/autodiff/test/flash_attention_v2/run.py
+++ b/third_party/autodiff/test/flash_attention_v2/run.py
@@ -1,16 +1,14 @@
-
 import numpy as np
 import torch
 import triton
-# torch.set_printoptions(sci_mode=False, linewidth=1000)
 
-# comment: at import this also runs asserts comparing fwd out with torch's
-from utils import kernel, stub, BLOCK_M
+from triton.backends.autodiff import autodiff
+from utils import kernel, stub
 
 
 torch.manual_seed(20)
+# torch.set_printoptions(sci_mode=False, linewidth=1000)
 DEVICE = torch.device("cuda:0")
-
 
 # comment: M tensor is float32 -- while others are float16
 
@@ -26,9 +24,6 @@ sm_scale=0.5
 q = torch.empty((B, NUM_HEADS, SEQ_LEN, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5)
 k = torch.empty((B, NUM_HEADS, SEQ_LEN, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5)
 v = torch.empty((B, NUM_HEADS, SEQ_LEN, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5)
-
-grid = (triton.cdiv(q.shape[2], BLOCK_M), q.shape[0] * q.shape[1], 1)
-
 
 
 # reference implementation
@@ -52,11 +47,13 @@ def torch_fn(q, k, v, causal, sm_scale):
     return ref_out
 
 
+my_op = autodiff(kernel, stub, idx_upstream=5, idxs_buffers=[3])
+
 
 #### test forward ####
 print("\n" * 4, "forward:")
 output_torch = torch_fn(q, k, v, causal, sm_scale)
-output_triton = stub(kernel, q, k, v, causal, sm_scale)
+output_triton = stub(my_op, q, k, v, causal, sm_scale)
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 
 print("output_torch:", output_torch[0, 0, :4, :4])
@@ -73,33 +70,15 @@ else:
 
 
 #### test backward ####
-print("\n" * 4, "backward warmup:")
+print("\n" * 4, "backward:")
 
 upstream = torch.randn_like(q)
 q.requires_grad = True
 k.requires_grad = True
 v.requires_grad = True
 
-from triton.backends.autodiff import autodiff
 
-
-# todo: need to support passing no grad args (in this case "causal, sm_scale") -- and my torch.Function needs to know to not output derivatives wrt them
-# my_out = my_op(q, k, v, causal, sm_scale)
-from functools import partial
-# here binding trailing arguments (not arguments at the beginning), bc kernel happen to have these at the end
-def right_partial(func, *args):
-    return lambda *fargs: func(*fargs, *args)
-stub = right_partial(stub, causal, sm_scale)
-
-# now this uses the stub which only needs grad args (non grad args have been bound)
-my_op, bwd_kernel = autodiff(kernel, stub, grid, idx_upstream=5, non_stub_args_idxs=[3])
-
-# todo: rm warmup
-stub(bwd_kernel, q, k, v)
-
-print("\n" * 4, "backward:")
-
-my_out = my_op(q, k, v)
+my_out = stub(my_op, q, k, v, causal, sm_scale)
 my_out.backward(upstream)
 print("grad q[0, 0, :4, :4]: ", q.grad[0, 0, :4, :4])
 print("grad k[0, 0, :4, :4]: ", k.grad[0, 0, :4, :4])

--- a/third_party/autodiff/test/flash_attention_v2/utils.py
+++ b/third_party/autodiff/test/flash_attention_v2/utils.py
@@ -3,24 +3,10 @@
 
 # - this is non causal only (so no need for the 2nd call to _attn_fwd_inner)
 
-# // one block + sm_scale (float arg) is constexpr
-
-# // !!! non causal
-
-
-
 # CHANGE LOG
-#   - made kernels args that are used as loop bounds -- to be tl.constexpr
+#   - made kernels args that are used as loop bounds -- tl.constexpr
 #     - start_m
 #     - almost all args to _attn_fwd
-#
-#   - reduced the range of inputs for benchmark (for speed of iter)
-
-#   - ==> yeah problem is that variable needed for loop boundaries "start_m = tl.program_id(0)" -- 
-
-
-
-# Made sm_scale a constepr (it was the only non ptr arg) -- so need special handing to compute grad wrt it
 
 # %%
 import pytest
@@ -29,9 +15,6 @@ import torch
 import triton
 import triton.language as tl
 
-print(triton.__path__)
-
-# DEVICE = triton.runtime.driver.active.get_active_torch_device()
 DEVICE = torch.device("cuda:0")
 
 
@@ -63,14 +46,6 @@ def keep(conf):
 # https://github.com/triton-lang/triton/blob/105cb56487cd8a433b8fbfe9cc63c1f1c04a4b2a/python/tutorials/06-fused-attention.py
 
 
-# %% [markdown]
-# ## Simplified
-# 
-# - this is non causal only (so no need for the 2nd call to _attn_fwd_inner)
-
-# %%
-
-
 @triton.jit
 def _attn_fwd_inner(acc, l_i, m_i, q,  #
                     K_block_ptr, V_block_ptr,  #
@@ -80,9 +55,6 @@ def _attn_fwd_inner(acc, l_i, m_i, q,  #
                     N_CTX: tl.constexpr):
     # range of values handled by this stage
     # causal = False
-    # answer-now: hardcoded N_CTX=16, here bc even though I'm passing compiled time constant -- it still shomehow makes the bounds dynamic
-    #   _attn_fwd_inner is inlined into the outer kernel, but its N_CTX is forwarded as an SSA argument so the entry point keeps a uniform parameter that the host sets at launch (just like grid size).
-    #   Until the very last “constant-prop + canonicalize” sweep runs, the loop boundary therefore looks dynamic
     lo, hi = 0, N_CTX
 
     K_block_ptr = tl.advance(K_block_ptr, (0, lo))
@@ -115,7 +87,7 @@ def _attn_fwd_inner(acc, l_i, m_i, q,  #
     return acc, l_i, m_i
 
 
-# answer-now: added do not specilize, other wise trtion adds them as constants as oppose to arguments -- and this is different from my causal=True case -- thus to avoid chaning what params I pass to the bwd kenrel in my bwd.py every time I filp "causal" flag -- thus here I just specialized them
+# todo: rm do_not_specialize
 @triton.jit(do_not_specialize=["stride_qz", "stride_qh", "stride_qm", "stride_qk",  "stride_kn", "stride_kk",  "stride_vk", "stride_vn",  "stride_om", "stride_on", "Z", "H"]) # , "N_CTX"
 def _attn_fwd(Q, K, V, sm_scale: tl.constexpr, M, Out,  #
               stride_qz, stride_qh, stride_qm, stride_qk,  # 
@@ -200,10 +172,7 @@ def _attn_fwd(Q, K, V, sm_scale: tl.constexpr, M, Out,  #
 
 
 
-
-_COMPILED_KERNEL = None
-
-# answer-now: this works but unrolls the loop too many times
+# todo: unrolls the loop too many times
 # BLOCK_M = 128
 # BLOCK_N = 64
 
@@ -223,14 +192,11 @@ def stub(kernel, q, k, v, causal, sm_scale):
     stage = 3 if causal else 1
     print("stage: ", stage)
 
-
-    # answer-now: lauch only one block in PID-1 -- to make loops unrollable
     grid = (triton.cdiv(q.shape[2], BLOCK_M), q.shape[0] * q.shape[1], 1)
     print("grid: ", grid)
 
     M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
-    global _COMPILED_KERNEL
-    _COMPILED_KERNEL = kernel[grid](
+    kernel[grid](
         q, k, v, sm_scale, M, o,  #
         q.stride(0), q.stride(1), q.stride(2), q.stride(3),  #
         # k.stride(0), k.stride(1), 
@@ -279,7 +245,7 @@ def test_op(Z, H, N_CTX, HEAD_DIM, causal, dtype=torch.float16):
 
     # triton implementation
     tri_out = attention(kernel, q, k, v, causal, sm_scale).half()
-    # comment: commented this out bc I'm using smaller shapes now but the bwd has this assert (requries a larger shape)
+    # comment: commented this out bc I'm using smaller shapes now but the bwd has this assert (requires a larger shape)
     #    PRE_BLOCK = 128
     #    assert N_CTX % PRE_BLOCK == 0
 
@@ -299,21 +265,13 @@ def test_op(Z, H, N_CTX, HEAD_DIM, causal, dtype=torch.float16):
     # assert torch.allclose(ref_dq, tri_dq, atol=1e-2, rtol=rtol)
     return tri_out, ref_out
 
-# NOTE: this works but unrolls for loop too many -- so try smaller shapes
-# tri_out, ref_out = test_op(1, 1, 128, 64, True)
+# todo: works but unrolls for loop too many -- so try smaller shapes
+# tri_out, ref_out = test_op(1, 1, 128, 64, causal=True)
 
-
-
-
-# NOTE: causal False
-tri_out, ref_out = test_op(1, 1, 16, 16, False)
-
+tri_out, ref_out = test_op(1, 1, 16, 16, causal=False)
 
 # # %%
 # tri_out[0, 0, :4, :4]
 
 # # %%
 # ref_out[0, 0, :4, :4]
-
-# %%
-# print("IR", _COMPILED_KERNEL.asm['ttir']) # triton IR

--- a/third_party/autodiff/test/for-loop-mm_static-bounds/run.py
+++ b/third_party/autodiff/test/for-loop-mm_static-bounds/run.py
@@ -2,12 +2,13 @@ import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
 import torch
-DEVICE = torch.device("cuda:0")
-
 import triton
 import triton.language as tl
 
+from triton.backends.autodiff import autodiff
 
+torch.manual_seed(0)
+DEVICE = torch.device("cuda:0")
 
 # - removed
 #   - masks
@@ -110,14 +111,16 @@ def stub(
     )
     return c
 
-torch.manual_seed(0)
+# todo: passing grid with meta args isn't supported yet
+my_op = autodiff(kernel, stub, idx_upstream=2)
+
 a = torch.randn((32, 32), device=DEVICE, dtype=torch.float16)
 b = torch.randn((32, 32), device=DEVICE, dtype=torch.float16)
 
 def torch_fn(a, b):
     return torch.matmul(a, b)
 
-triton_output = stub(kernel, a, b)
+triton_output = stub(my_op, a, b)
 torch_output = torch_fn(a, b)
 # print(f"triton_output_with_fp16_inputs={triton_output[:4, :4]}")
 # print(f"torch_output_with_fp16_inputs={torch_output[:4, :4]}")
@@ -130,17 +133,12 @@ else:
 
 #### test backward ####
 
-from triton.backends.autodiff import autodiff
-
-# todo: passing grid with meta args isn't supported yet
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(4, 1, 1), idx_upstream=2)
 
 upstream = torch.randn_like(torch_output)
 a.requires_grad = True
 b.requires_grad = True
 
-stub(bwd_kernel, a, b)
-my_out = my_op(a, b)
+my_out = stub(my_op, a, b)
 my_out.backward(upstream)
 print("grad a: ", a.grad)
 print("grad b: ", b.grad)

--- a/third_party/autodiff/test/for-loop/run.py
+++ b/third_party/autodiff/test/for-loop/run.py
@@ -2,11 +2,12 @@ import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
 import torch
-torch.manual_seed(0)
-
 import triton
 import triton.language as tl
 
+from triton.backends.autodiff import autodiff
+
+torch.manual_seed(0)
 DEVICE = torch.device("cuda:0")
 
 
@@ -49,11 +50,14 @@ def torch_fn(torch_a):
     return accum
 
 
+# todo-high: grid with meta is not supported when calling bwd kernel (presumably BLOCK_SIZE got already inlined)
+my_op = autodiff(kernel, stub, idx_upstream=1)
+
 size = 4
 a = torch.randn(size, device=DEVICE)
 
 output_torch = torch_fn(a)
-output_triton = stub(kernel, a)
+output_triton = stub(my_op, a)
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 
 # print("output_torch:", output_torch[:3, :3])
@@ -87,14 +91,7 @@ print()
 
 # triton autograd
 
-from triton.backends.autodiff import autodiff
-
-# todo-high: grid with meta is not supported when calling bwd kernel (presumably BLOCK_SIZE got already inlined)
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(1, ), idx_upstream=1)
-
-# todo: rm warmup
-stub(bwd_kernel, a)
-my_out = my_op(a)
+my_out = stub(my_op, a)
 # todo-now: calling this doubles torch grad!
 my_out.backward(upstream)
 print("grad a: ", a.grad)

--- a/third_party/autodiff/test/layernorm/run.py
+++ b/third_party/autodiff/test/layernorm/run.py
@@ -1,13 +1,16 @@
 import numpy as np
 import torch
 import triton
-# torch.set_printoptions(sci_mode=False, linewidth=1000)
 
+from triton.backends.autodiff import autodiff
 from utils import kernel, stub
 
 torch.manual_seed(20)
+# torch.set_printoptions(sci_mode=False, linewidth=1000)
 DEVICE = torch.device("cuda:0")
 
+
+my_op = autodiff(kernel, stub, idx_upstream=1, idxs_buffers=[4,5])
 
 M = 1151 # 256 # 32
 N = 8192 # 256 # 32
@@ -31,7 +34,7 @@ upstream = .1 * torch.randn_like(x)
 
 #### test forward ####
 
-output_triton = stub(kernel, x, weight, bias, eps=1e-5)
+output_triton = stub(my_op, x, weight, bias, eps=1e-5)
 output_torch = torch.nn.functional.layer_norm(x, w_shape, weight, bias, eps=1e-5)
 
 # print("output_torch:", output_torch[:3, :3])
@@ -54,13 +57,7 @@ weight.requires_grad = True
 bias.requires_grad = True
 
 
-from triton.backends.autodiff import autodiff
-
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(M,), non_stub_args_idxs=[4,5], idx_upstream=1)
-
-# todo: rm warmup
-stub(bwd_kernel, x, weight, bias)
-my_out = my_op(x, weight, bias)
+my_out = stub(my_op, x, weight, bias)
 my_out.backward(upstream)
 
 print("x grad: ", x.grad)

--- a/third_party/autodiff/test/mask_multiblock_add-mul/run.py
+++ b/third_party/autodiff/test/mask_multiblock_add-mul/run.py
@@ -1,13 +1,13 @@
-# 5) masked and multi-block: Add + Mull
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
-
 
 import torch
 
 import triton
 import triton.language as tl
+from triton.backends.autodiff import autodiff
 
+torch.manual_seed(0)
 DEVICE = torch.device("cuda:0")
 
 
@@ -46,8 +46,8 @@ def stub(kernel, a, b, BLOCK_SIZE=4):
     kernel[grid](a, b, output, BLOCK_SIZE)
     return output
 
+my_op = autodiff(kernel, stub, idx_upstream=2)
 
-torch.manual_seed(0)
 
 size = 10
 a = torch.rand(size, device=DEVICE)
@@ -59,7 +59,7 @@ def torch_fn(torch_a, torch_b):
     return (torch_a + 0.5) * torch_b
 
 output_torch = torch_fn(a, b)
-output_triton = stub(kernel, a, b)
+output_triton = stub(my_op, a, b)
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 
 # print(output_torch)
@@ -80,13 +80,7 @@ upstream = torch.randn_like(a)
 a.requires_grad = True
 b.requires_grad = True
 
-from triton.backends.autodiff import autodiff
-
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(3, 1, 1), idx_upstream=2)
-
-# todo: rm warmup
-stub(bwd_kernel, a, b)
-my_out = my_op(a, b)
+my_out = stub(my_op, a, b)
 my_out.backward(upstream)
 
 # print("grad a: ", grad_a)

--- a/third_party/autodiff/test/math-ops/run.py
+++ b/third_party/autodiff/test/math-ops/run.py
@@ -1,12 +1,13 @@
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
-
 import torch
-
 import triton
 import triton.language as tl
 
+from triton.backends.autodiff import autodiff
+
+torch.manual_seed(0)
 DEVICE = torch.device("cuda:0")
 
 
@@ -45,7 +46,10 @@ def stub(kernel, a, b, c):
     kernel[grid](a, b, c, output)
     return output
 
-torch.manual_seed(0)
+
+my_op = autodiff(kernel, stub, idx_upstream=3)
+
+
 size = 4
 a = torch.rand(size, device=DEVICE)
 b = torch.rand(size, device=DEVICE)
@@ -69,7 +73,7 @@ def torch_fn(a, b, c):
 
 
 output_torch = torch_fn(a, b, c)
-output_triton = stub(kernel, a, b, c)
+output_triton = stub(my_op, a, b, c)
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 
 # print(output_torch)
@@ -91,14 +95,7 @@ a.requires_grad = True
 b.requires_grad = True
 c.requires_grad = True
 
-
-from triton.backends.autodiff import autodiff
-
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(1,), idx_upstream=3)
-
-# todo: rm warmup
-stub(bwd_kernel, a, b, c)
-my_out = my_op(a, b, c)
+my_out = stub(my_op, a, b, c)
 my_out.backward(upstream)
 
 # print("grad a: ", a.grad)

--- a/third_party/autodiff/test/multi-use/run.py
+++ b/third_party/autodiff/test/multi-use/run.py
@@ -1,14 +1,14 @@
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
-
 import torch
-
 import triton
 import triton.language as tl
 
-DEVICE = torch.device("cuda:0")
+from triton.backends.autodiff import autodiff
 
+torch.manual_seed(0)
+DEVICE = torch.device("cuda:0")
 
 
 @triton.jit
@@ -32,7 +32,8 @@ def stub(kernel, a):
     kernel[(1, 1, 1)](a, output, BLOCK_SIZE=4)
     return output
 
-torch.manual_seed(0)
+
+my_op = autodiff(kernel, stub, idx_upstream=1)
 
 size = 4
 a = torch.rand(size, device=DEVICE)
@@ -42,7 +43,7 @@ def torch_fn(a):
     return a * (a + 0.5)
 
 output_torch = torch_fn(a)
-output_triton = stub(kernel, a)
+output_triton = stub(my_op, a)
 max_difference = torch.max(torch.abs(output_torch - output_triton))
 
 # print(output_torch)
@@ -62,14 +63,7 @@ else:
 upstream = torch.randn_like(a)
 a.requires_grad = True
 
-
-from triton.backends.autodiff import autodiff
-
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(1,), idx_upstream=1)
-
-# todo: rm warmup
-stub(bwd_kernel, a)
-my_out = my_op(a)
+my_out = stub(my_op, a)
 my_out.backward(upstream)
 
 # print("grad a: ", grad_a)

--- a/third_party/autodiff/test/multiblock_add-mul/run.py
+++ b/third_party/autodiff/test/multiblock_add-mul/run.py
@@ -2,12 +2,13 @@
 import os
 os.environ['TRITON_ALWAYS_COMPILE']='1'
 
-
 import torch
-
 import triton
 import triton.language as tl
 
+from triton.backends.autodiff import autodiff
+
+torch.manual_seed(0)
 DEVICE = torch.device("cuda:0")
 
 
@@ -49,7 +50,8 @@ def stub(kernel, a, b, BLOCK_SIZE=4):
     # running asynchronously at this point.
     return output
 
-torch.manual_seed(0)
+
+my_op = autodiff(kernel, stub, idx_upstream=2)
 
 size = 8
 a = torch.rand(size, device=DEVICE)
@@ -63,7 +65,7 @@ def torch_fn(a, b):
 # forward
 
 output_torch = torch_fn(a, b)
-output_triton = stub(kernel, a, b)
+output_triton = stub(my_op, a, b)
 # print(output_torch)
 # print(output_triton)
 
@@ -84,14 +86,7 @@ upstream = torch.randn_like(a)
 a.requires_grad = True
 b.requires_grad = True
 
-
-from triton.backends.autodiff import autodiff
-
-my_op, bwd_kernel = autodiff(kernel, stub, grid=(2,), idx_upstream=2)
-
-# todo: rm warmup
-stub(bwd_kernel, a, b)
-my_out = my_op(a, b)
+my_out = stub(my_op, a, b)
 my_out.backward(upstream)
 
 # print("grad a: ", grad_a)

--- a/third_party/autodiff/test/run_all_tests.py
+++ b/third_party/autodiff/test/run_all_tests.py
@@ -1,21 +1,27 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 import subprocess
 
 if __name__ == "__main__":
 
-  for test_name in ["add", "add-mul", "div", "add-mul-div", "math-ops",
-                    "multiblock_add-mul", "mask_multiblock_add-mul",
-                    "2d_dot", "multi-use",
-                    "for-loop", "for-loop-mm_static-bounds",
-                    "LOCAL_for-loop-mm-static-bounds_simple", "LOCAL_for-loop-mm-static-bounds_actual",
-                    "flash_attention_v2", "layernorm"]:
-  # for test_name in ["flash_attention_v2"]:
+  tests = [
+    "add", "add-mul", "div", "add-mul-div", "math-ops",
+    "multiblock_add-mul", "mask_multiblock_add-mul",
+    "2d_dot", "multi-use",
+    "for-loop", "for-loop-mm_static-bounds",
+    "flash_attention_v2", "layernorm"
+  ]
 
+  if int(os.environ.get('EXTRA', 0)):
+    tests.extend([
+      "LOCAL_for-loop-mm-static-bounds_simple",
+      "LOCAL_for-loop-mm-static-bounds_actual"
+    ])
+
+  for test_name in tests:
     print("~" * 20 + f" Running {test_name} " + "~" * 20)
-
     # produce fwd and bwd ttir; and compare outs and grads with torch
     subprocess.run([sys.executable, "run.py"], cwd=test_name)
-
   print("~" * 50)


### PR DESCRIPTION
key advantages of py-api-v3 (compared to py-api-v2):
- relies on torch autodiff to differentiate through all the logic in the stub (outside of the kernel) -- instead of asking users to manually differentiate them (v2 required users specify `post_process_fn`)
    - now made `DifferentiatedCompiledKernel` operate on the level of kernels -- much cleaner semantics: it takes care of differentiating everything inside that AG.Function (and because it's on the kernel level -- it only needs to diff the kernel); and everything outside of that AG.Function -- it's not responsible for (relying on torch)
- removes warmup (that step of needing to call bwd kernel once before calling `DifferentiatedCompiledKernel.backward`)
- removes 2X compilation overhead -- perviously I was lowering fwd source code to ttir twice (once in fwd JITFunction; and another time in bwd JITFunction) -- now I just lower once (in fwd JITFunciton) and install a differentiated version of that IR in directly in the bwd JITFucntion -- so by the time bwd jit-fn runs it already has a differentiated cache entry: no need to recompile
- does not input "grid" from usr
- supports kwargs (wt needing hacks like `right_partial`)